### PR TITLE
fixed https://github.com/NetCommons3/NetCommons3/issues/379

### DIFF
--- a/View/Elements/RegistrationEdit/EditQuestion/options_before_published/choice.ctp
+++ b/View/Elements/RegistrationEdit/EditQuestion/options_before_published/choice.ctp
@@ -13,6 +13,7 @@
 	   name="data[RegistrationPage][{{pageIndex}}][RegistrationQuestion][{{qIndex}}][RegistrationChoice][{{choice.choiceSequence}}][choice_label]"
 	   class="form-control input-sm"
 	   ng-model="choice.choiceLabel"
+	   nc-focus="true"
 		/>
 <span ng-if="choice.otherChoiceType != <?php echo RegistrationsComponent::OTHER_CHOICE_TYPE_NO_OTHER_FILED; ?>">
 	<?php echo __d('registrations', '(This is [other] choice. Area to enter the text is automatically granted at the time of implementation.)'); ?>


### PR DESCRIPTION
アンケート、小テストは修正箇所はここだけだったんですが、登録フォームがここだけでよいかはいまいち自信がないです。
追加選択肢要素を定義しているCTPのところに nc-focus="true"属性を書き足しておいてもらえたらOKなので、ご検討ください。
