### PR TITLE
fix: メール配信の「本人にも送る」を有効にしていると、ログインユーザのメアドとフォームに入力したメアドが同じときに重複してメールが送ら…

### DIFF
--- a/Model/RegistrationAnswerSummary.php
+++ b/Model/RegistrationAnswerSummary.php
@@ -530,12 +530,15 @@ class RegistrationAnswerSummary extends RegistrationsAppModel {
 					// メール項目あり
 
 					// メアドをregistration_answersから取得
-					$registUserMail = $answers[$index]['RegistrationAnswer']['answer_value'];
-					// 送信先にset
-					$this->setSetting(
-						MailQueueBehavior::MAIL_QUEUE_SETTING_TO_ADDRESSES,
-						[$registUserMail]
-					);
+					$registerUserMail = $answers[$index]['RegistrationAnswer']['answer_value'];
+
+					if (!$this->__isSameLoginUserEmail($registerUserMail)) {
+						// 送信先にset
+						$this->setSetting(
+							MailQueueBehavior::MAIL_QUEUE_SETTING_TO_ADDRESSES,
+							[$registerUserMail]
+						);
+					}
 					// ループから抜ける
 					break;
 				}
@@ -543,4 +546,14 @@ class RegistrationAnswerSummary extends RegistrationsAppModel {
 		}
 	}
 
+/**
+ * __isSameLoginUserEmail
+ *
+ * @param string $registerUserMail email
+ * @return bool
+ */
+	private function __isSameLoginUserEmail($registerUserMail) {
+		$email = Current::read('User.email');
+		return ($email === $registerUserMail);
+	}
 }

--- a/Test/Case/Controller/RegistrationAnswersController/PostTest.php
+++ b/Test/Case/Controller/RegistrationAnswersController/PostTest.php
@@ -341,6 +341,15 @@ class RegistrationAnswersControllerPostTest extends NetCommonsControllerTestCase
 		//ログイン
 		TestAuthGeneral::login($this, Role::ROOM_ROLE_KEY_ROOM_ADMINISTRATOR);
 
+		$mailSettingMock = $this->getMockForModel('Mails.MailSetting', ['getMailSettingPlugin']);
+		$mailSettingMock->expects($this->any())
+			->method('getMailSettingPlugin')
+			->will($this->returnValue([
+				'MailSetting' => [
+					'is_mail_send' => false,
+				]
+			]));
+
 		$data = array(
 			'data' => array(
 				'Frame' => array('id' => 26),

--- a/Test/Case/Model/RegistrationAnswerSummary/SaveAnswerStatusTest.php
+++ b/Test/Case/Model/RegistrationAnswerSummary/SaveAnswerStatusTest.php
@@ -63,8 +63,9 @@ class SaveAnswerStatusTest extends NetCommonsModelTestCase {
  * @var array
  */
 	protected $_methodName = 'saveAnswerStatus';
+	private $__mailSettingMock;
 
-/**
+	/**
  * setUp method
  *
  * @return void
@@ -105,6 +106,16 @@ class SaveAnswerStatusTest extends NetCommonsModelTestCase {
 		$registrationMock->expects($this->any())
 			->method('find')
 			->will($this->returnValue($registration));
+
+		$this->__mailSettingMock = $this->getMockForModel('Mails.MailSetting', ['getMailSettingPlugin']);
+		$this->__mailSettingMock->expects($this->any())
+			->method('getMailSettingPlugin')
+			->will($this->returnValue([
+				'MailSetting' => [
+					'is_mail_send' => false,
+				]
+			]));
+		$this->$model->MailSetting = $this->__mailSettingMock;
 	}
 
 /**
@@ -203,6 +214,7 @@ class SaveAnswerStatusTest extends NetCommonsModelTestCase {
 		$model = $this->_modelName;
 		$method = $this->_methodName;
 		$this->_mockForReturnFalse($model, $mockModel, $mockMethod);
+		$this->$model->MailSetting = $this->__mailSettingMock;
 		$result = $this->$model->$method($data, $status);
 		$this->assertFalse($result);
 	}
@@ -237,6 +249,7 @@ class SaveAnswerStatusTest extends NetCommonsModelTestCase {
 		$this->_mockForReturnFalse($model, $mockModel, $mockMethod);
 
 		$this->setExpectedException('InternalErrorException');
+		$this->$model->MailSetting = $this->__mailSettingMock;
 		$this->$model->$method($data, $status);
 	}
 /**

--- a/Test/Case/Model/RegistrationAnswerSummary/SaveAnswerStatusTest.php
+++ b/Test/Case/Model/RegistrationAnswerSummary/SaveAnswerStatusTest.php
@@ -63,9 +63,13 @@ class SaveAnswerStatusTest extends NetCommonsModelTestCase {
  * @var array
  */
 	protected $_methodName = 'saveAnswerStatus';
+
+/**
+ * @var MailSetting Mock
+ */
 	private $__mailSettingMock;
 
-	/**
+/**
  * setUp method
  *
  * @return void


### PR DESCRIPTION
…れてしまうのを修正。 Refs https://github.com/researchmap/RmNetCommons3/issues/1704

メアドが同じときはフォームに登録されたメアドはメールプラグインに渡さないようにした。