### PR TITLE
Feature/specification change4mail

### DIFF
--- a/Controller/RegistrationEditController.php
+++ b/Controller/RegistrationEditController.php
@@ -467,12 +467,12 @@ class RegistrationEditController extends RegistrationsAppController {
 		$this->request->data['Block'] = Current::read('Block');
 
 		// メール通知設定
-		$conditions = [
-			'plugin_key' => 'registrations',
-			'block_key' => Current::read('Block.key')
-		];
-		$mailSetting = $this->MailSetting->find('first', ['conditions' => $conditions]);
-		$this->set('mailSetting', $mailSetting);
+		//$conditions = [
+		//	'plugin_key' => 'registrations',
+		//	'block_key' => Current::read('Block.key')
+		//];
+		//$mailSetting = $this->MailSetting->find('first', ['conditions' => $conditions]);
+		//$this->set('mailSetting', $mailSetting);
 	}
 
 /**

--- a/Model/Behavior/MailSettingBehavior.php
+++ b/Model/Behavior/MailSettingBehavior.php
@@ -55,10 +55,8 @@ class MailSettingBehavior extends ModelBehavior {
 		);
 		if (! Hash::check($mailSetting, 'MailSetting.id')) {
 			// まだメール設定がないときは、登録フォームで登録通知メールONならメール設定も送信する設定にする。
-			//$mailSetting = $model->MailSetting->createMailSetting($model->alias);
+			// 　上記はとりやめて、「メール通知機能を使う」と「登録通知メールを送る」のOn/Offは連動しないように変更
 			$model->MailSetting->create();
-			$mailSetting['MailSetting']['is_mail_send'] =
-				$saveRegistration['Registration']['is_answer_mail_send'];
 			$model->MailSettingFixedPhrase->create();
 		}
 		// 登録通知メール設定を変更

--- a/Model/Registration.php
+++ b/Model/Registration.php
@@ -674,6 +674,7 @@ class Registration extends RegistrationsAppModel {
 
 			// Registrationのステータスが公開なら登録通知メール設定を上書きする
 			if ($status == WorkflowComponent::STATUS_PUBLISHED) {
+				/** @see \MailSettingBehavior::updateMailSetting */
 				$this->updateMailSetting($saveRegistration);
 			}
 

--- a/Model/RegistrationAnswerSummary.php
+++ b/Model/RegistrationAnswerSummary.php
@@ -471,9 +471,10 @@ class RegistrationAnswerSummary extends RegistrationsAppModel {
 		$mailSettingPlugin = $this->MailSetting->getMailSettingPlugin(
 			null, MailSettingFixedPhrase::ANSWER_TYPE
 		);
-		$isMailSend = Hash::get($mailSettingPlugin, 'MailSetting.is_mail_send');
+//		$isMailSend = Hash::get($mailSettingPlugin, 'MailSetting.is_mail_send');
 
-		if (! $registration['Registration']['is_answer_mail_send'] || ! $isMailSend) {
+//		if (! $registration['Registration']['is_answer_mail_send'] || ! $isMailSend) {
+		if (! $registration['Registration']['is_answer_mail_send']) {
 			$this->Behaviors->unload('Mails.MailQueue');
 			return;
 		}

--- a/Model/RegistrationAnswerSummary.php
+++ b/Model/RegistrationAnswerSummary.php
@@ -464,16 +464,16 @@ class RegistrationAnswerSummary extends RegistrationsAppModel {
 		$condition = $this->Registration->getBaseCondition();
 		$registration = $this->Registration->find('first', ['conditions' => $condition]);
 
-		/** @see MailSetting::getMailSettingPlugin() */
-		$this->loadModels([
-			'SiteSetting' => 'SiteManager.SiteSetting',
-		]);
-		$mailSettingPlugin = $this->MailSetting->getMailSettingPlugin(
-			null, MailSettingFixedPhrase::ANSWER_TYPE
-		);
-//		$isMailSend = Hash::get($mailSettingPlugin, 'MailSetting.is_mail_send');
-
-//		if (! $registration['Registration']['is_answer_mail_send'] || ! $isMailSend) {
+		///** @see MailSetting::getMailSettingPlugin() */
+		//$this->loadModels([
+		//	'SiteSetting' => 'SiteManager.SiteSetting',
+		//]);
+		//$mailSettingPlugin = $this->MailSetting->getMailSettingPlugin(
+		//	null, MailSettingFixedPhrase::ANSWER_TYPE
+		//);
+		//$isMailSend = Hash::get($mailSettingPlugin, 'MailSetting.is_mail_send');
+		//
+		//if (! $registration['Registration']['is_answer_mail_send'] || ! $isMailSend) {
 		if (! $registration['Registration']['is_answer_mail_send']) {
 			$this->Behaviors->unload('Mails.MailQueue');
 			return;

--- a/View/Elements/RegistrationEdit/Edit/mail_setting.ctp
+++ b/View/Elements/RegistrationEdit/Edit/mail_setting.ctp
@@ -1,71 +1,65 @@
 <?php echo $this->NetCommonsForm->label('', __d('registrations', 'Deliver e-mail when submitted?')); ?>
-<?php if (Hash::get($mailSetting, 'MailSetting.is_mail_send') === false) : ?>
-	<div class="alert alert-warning">
-		<?php echo __d('registrations', 'E-mail notifications are disabled'); ?>
-	</div>
-<?php else : ?>
-		<?php
-		/* 登録通知メール設定 */
-		echo $this->RegistrationEdit->registrationAttributeCheckbox('is_answer_mail_send',
-			__d('registrations', 'Answer mail send'),
-			array());
-		?>
-		<div class="row" ng-show="registration.registration.isAnswerMailSend ==
-			'<?php echo RegistrationsComponent::USES_USE; ?>'">
+<?php
+/* 登録通知メール設定 */
+echo $this->RegistrationEdit->registrationAttributeCheckbox('is_answer_mail_send',
+	__d('registrations', 'Answer mail send'),
+	array());
+?>
+<div class="row" ng-show="registration.registration.isAnswerMailSend ==
+	'<?php echo RegistrationsComponent::USES_USE; ?>'">
 
+<div class="col-xs-11 col-xs-offset-1">
+
+
+	<?php
+	/* 本人にも送る（メールアドレス項目があるときのみ） */
+	echo $this->RegistrationEdit->registrationAttributeCheckbox('is_regist_user_send',
+		__d('registrations', 'Notify the applicant by e-mail,if there is metadata of e-mail'),
+		array());
+	?>
+	<div class="row" ng-show="registration.registration.isRegistUserSend ==
+		'<?php echo RegistrationsComponent::USES_USE; ?>'">
 		<div class="col-xs-11 col-xs-offset-1">
-
-
-			<?php
-			/* 本人にも送る（メールアドレス項目があるときのみ） */
-			echo $this->RegistrationEdit->registrationAttributeCheckbox('is_regist_user_send',
-				__d('registrations', 'Notify the applicant by e-mail,if there is metadata of e-mail'),
-				array());
-			?>
-			<div class="row" ng-show="registration.registration.isRegistUserSend ==
-				'<?php echo RegistrationsComponent::USES_USE; ?>'">
-				<div class="col-xs-11 col-xs-offset-1">
-					<div class="form-group">
-						<?php echo $this->NetCommonsForm->input('Registration.reply_to', array(
-							'type' => 'text',
-							'label' => __d('mails', 'E-mail address to receive a reply'),
-							'div' => '',
-							'help' => __d('mails', 'You can specify if you want to change the e-mail address to receive a reply'),
-						)); ?>
-					</div>
-				</div>
+			<div class="form-group">
+				<?php echo $this->NetCommonsForm->input('Registration.reply_to', array(
+					'type' => 'text',
+					'label' => __d('mails', 'E-mail address to receive a reply'),
+					'div' => '',
+					'help' => __d('mails', 'You can specify if you want to change the e-mail address to receive a reply'),
+				)); ?>
 			</div>
-			<div class="panel panel-default">
-				<div class="panel-heading">
-					<?php echo __d('registrations', 'Registration mail') ?>
-				</div>
-				<div class="panel-body">
+		</div>
+	</div>
+	<div class="panel panel-default">
+		<div class="panel-heading">
+			<?php echo __d('registrations', 'Registration mail') ?>
+		</div>
+		<div class="panel-body">
 
-					<?php echo $this->NetCommonsForm->input('Registration.registration_mail_subject', array(
-						'type' => 'text',
-						'label' => __d('mails', 'Subject'),
-						'required' => true,
-						//'value' => $mailSettingFixedPhrase['mail_fixed_phrase_subject'],
-					)); ?>
+			<?php echo $this->NetCommonsForm->input('Registration.registration_mail_subject', array(
+				'type' => 'text',
+				'label' => __d('mails', 'Subject'),
+				'required' => true,
+				//'value' => $mailSettingFixedPhrase['mail_fixed_phrase_subject'],
+			)); ?>
 
-					<div class="form-group">
-						<?php echo $this->NetCommonsForm->input('Registration.registration_mail_body', array(
-							'type' => 'textarea',
-							'label' => __d('mails', 'Body'),
-							'required' => true,
-							//'value' => $mailSettingFixedPhrase['mail_fixed_phrase_body'],
-							'div' => '',
-						)); ?>
-						<?php
-						// popover説明
-						$mailHelp = $this->NetCommonsHtml->mailHelp(__d('registrations', 'Registration.mail.popover'));
-						echo $this->NetCommonsForm->help($mailHelp);
-						?>
-					</div>
-				</div>
+			<div class="form-group">
+				<?php echo $this->NetCommonsForm->input('Registration.registration_mail_body', array(
+					'type' => 'textarea',
+					'label' => __d('mails', 'Body'),
+					'required' => true,
+					//'value' => $mailSettingFixedPhrase['mail_fixed_phrase_body'],
+					'div' => '',
+				)); ?>
+				<?php
+				// popover説明
+				$mailHelp = $this->NetCommonsHtml->mailHelp(__d('registrations', 'Registration.mail.popover'));
+				echo $this->NetCommonsForm->help($mailHelp);
+				?>
 			</div>
-
 		</div>
+	</div>
 
-		</div>
-<?php endif;
+</div>
+
+</div>


### PR DESCRIPTION
<img width="829" alt="SpecificationChange4mail" src="https://user-images.githubusercontent.com/1955236/88756330-5b003680-d19e-11ea-974b-7b760a42046a.png">

これまで、フォームに回答するとメールされる「登録通知メール」の設定は「メール通知機能を使う」がONでないと設定できませんでした。

これを「メール通知機能を使う」とは無関係に「登録通知メール」の設定をできるようにしました。

これにより、
「メール通知機能を使う」はOff（フォームが公開されたことのメール通知はしない）　のまま「登録通知メールを送る」をOn（フォームへの回答はメール通知する）ことができるようになります。
