### PR TITLE
フォーム作成時とことなる言語でフォーム送信されたときの登録通知メールの問題を修正

### DIFF
--- a/Model/Behavior/MailSettingBehavior.php
+++ b/Model/Behavior/MailSettingBehavior.php
@@ -86,14 +86,7 @@ class MailSettingBehavior extends ModelBehavior {
 				'MailSettingFixedPhrase.contents.mail_setting_id',
 				$model->MailSetting->id
 			);
-			//$model->MailSettingFixedPhrase = ClassRegistry::init(
-			//	'Mails.MailSettingFixedPhrase'
-			//);
 			$answerPhrase = $mailSetting['MailSettingFixedPhrase']['answer'];
-			//$answerPhrase = array(
-			//	'MailSettingFixedPhrase' => $answerPhrase
-			//);
-			//if (!$model->MailSettingFixedPhrase->save($answerPhrase, ['callbacks' => false])) {
 			if (!$model->MailSettingFixedPhrase->save($answerPhrase)) {
 				throw new InternalErrorException(
 					__d('net_commons', 'Internal Server Error')
@@ -101,10 +94,6 @@ class MailSettingBehavior extends ModelBehavior {
 			}
 			$model->MailSettingFixedPhrase->create();
 			$contentsPhrase = $mailSetting['MailSettingFixedPhrase']['contents'];
-			//$contentsPhrase = array(
-			//	'MailSettingFixedPhrase' => $contentsPhrase
-			//);
-			//if (!$model->MailSettingFixedPhrase->save($contentsPhrase, ['callbacks' => false])) {
 			if (!$model->MailSettingFixedPhrase->save($contentsPhrase)) {
 				throw new InternalErrorException(
 					__d('net_commons', 'Internal Server Error')

--- a/Model/RegistrationAnswerSummary.php
+++ b/Model/RegistrationAnswerSummary.php
@@ -467,16 +467,6 @@ class RegistrationAnswerSummary extends RegistrationsAppModel {
 		//フォーム設定した文面でメールをおくれるようにMailQueueBehaviorを設定する。
 		$this->__setMailFixedPhraseForAllLanguages($registration);
 
-		///** @see MailSetting::getMailSettingPlugin() */
-		//$this->loadModels([
-		//	'SiteSetting' => 'SiteManager.SiteSetting',
-		//]);
-		//$mailSettingPlugin = $this->MailSetting->getMailSettingPlugin(
-		//	null, MailSettingFixedPhrase::ANSWER_TYPE
-		//);
-		//$isMailSend = Hash::get($mailSettingPlugin, 'MailSetting.is_mail_send');
-		//
-		//if (! $registration['Registration']['is_answer_mail_send'] || ! $isMailSend) {
 		if (! $registration['Registration']['is_answer_mail_send']) {
 			$this->Behaviors->unload('Mails.MailQueue');
 			return;
@@ -532,7 +522,6 @@ class RegistrationAnswerSummary extends RegistrationsAppModel {
 			foreach ($registration['RegistrationPage'][0]['RegistrationQuestion'] as $index => $question) {
 				if ($question['question_type'] == RegistrationsComponent::TYPE_EMAIL) {
 					// メール項目あり
-
 					// メアドをregistration_answersから取得
 					$registerUserMail = $answers[$index]['RegistrationAnswer']['answer_value'];
 

--- a/Model/RegistrationAnswerSummary.php
+++ b/Model/RegistrationAnswerSummary.php
@@ -563,7 +563,11 @@ class RegistrationAnswerSummary extends RegistrationsAppModel {
 		$typeKey = \MailSettingFixedPhrase::ANSWER_TYPE;
 		$settingPluginKey = 'registrations';
 
-		$mailSettingPlugin = $this->MailSetting->getMailSettingPlugin($languageId, $typeKey, $settingPluginKey);
+		$mailSettingPlugin = $this->MailSetting->getMailSettingPlugin(
+			$languageId,
+			$typeKey,
+			$settingPluginKey
+		);
 
 		// 有効になってる全言語に同じメール設定をセットする
 		foreach ($this->__findActiveLanguageIds() as $languageId) {


### PR DESCRIPTION
フォーム作成時の言語と異なる言語でフォームへの登録があったとききに送られる登録通知メールがフォーム編集で登録した件名・文面でなくDB登録されてるデフォルト文面で送信されていたのを、つねにフォーム編集画面で登録した件名・文面でメールが送られるようにした。